### PR TITLE
 Add server detector that will wait for Thorntail

### DIFF
--- a/src/main/java/com/heroku/agent/metrics/MetricsAgent.java
+++ b/src/main/java/com/heroku/agent/metrics/MetricsAgent.java
@@ -2,15 +2,24 @@ package com.heroku.agent.metrics;
 
 import java.io.IOException;
 import java.lang.instrument.Instrumentation;
+import java.util.Collections;
+import java.util.List;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.heroku.detector.JBossDetector;
+import com.heroku.detector.ServerDetector;
 import com.heroku.prometheus.client.BufferPoolsExports;
 import io.prometheus.client.hotspot.DefaultExports;
 
 public class MetricsAgent {
 
+  private static final List<ServerDetector> SERVER_DETECTORS =
+      Collections.singletonList((ServerDetector) new JBossDetector());
+
   public static void premain(String agentArgs, Instrumentation instrumentation) {
+    awaitServerInitialization(instrumentation);
+
     logDebug("premain", "starting");
     try {
       DefaultExports.initialize();
@@ -47,6 +56,12 @@ public class MetricsAgent {
     String debug = System.getenv("HEROKU_METRICS_DEBUG");
     if ("1".equals(debug) || "true".equals(debug)) {
       t.printStackTrace();
+    }
+  }
+
+  private static void awaitServerInitialization(final Instrumentation instrumentation) {
+    for (ServerDetector detector : SERVER_DETECTORS) {
+      detector.jvmAgentStartup(instrumentation);
     }
   }
 }

--- a/src/main/java/com/heroku/agent/metrics/MetricsAgent.java
+++ b/src/main/java/com/heroku/agent/metrics/MetricsAgent.java
@@ -17,11 +17,34 @@ public class MetricsAgent {
   private static final List<ServerDetector> SERVER_DETECTORS =
       Collections.singletonList((ServerDetector) new JBossDetector());
 
-  public static void premain(String agentArgs, Instrumentation instrumentation) {
-    awaitServerInitialization(instrumentation);
+  public static void premain(String agentArgs, final Instrumentation instrumentation) {
+    logDebug("premain", "detecting");
+    if (detectServers()) {
+      logDebug("premain", "starting daemon");
+      Thread thread = new Thread("HerokuMetricsAgent") {
+        public void run() {
+          startAgent(instrumentation);
+        }
+      };
+      thread.setDaemon(true);
+      thread.start();
+    } else {
+      logDebug("premain", "starting");
+      startAgent(instrumentation);
+    }
+  }
 
-    logDebug("premain", "starting");
+  static void logDebug(String at, String message) {
+    String debug = System.getenv("HEROKU_METRICS_DEBUG");
+    if ("1".equals(debug) || "true".equals(debug)) {
+      System.out.println("debug at=\"" + at + "\" component=heroku-java-metrics-agent message=\"" + message + "\"");
+    }
+  }
+
+  private static void startAgent(Instrumentation instrumentation) {
     try {
+      awaitServerInitialization(instrumentation);
+
       DefaultExports.initialize();
       new BufferPoolsExports().register();
 
@@ -43,13 +66,6 @@ public class MetricsAgent {
     }
   }
 
-  static void logDebug(String at, String message) {
-    String debug = System.getenv("HEROKU_METRICS_DEBUG");
-    if ("1".equals(debug) || "true".equals(debug)) {
-      System.out.println("debug at=\"" + at + "\" component=heroku-java-metrics-agent message=\"" + message + "\"");
-    }
-  }
-
   private static void logError(String at, Throwable t) {
     System.out.println("error at=\"" + at + "\" component=heroku-java-metrics-agent message=\"" + t.getMessage() + "\"");
 
@@ -59,8 +75,19 @@ public class MetricsAgent {
     }
   }
 
+  private static boolean detectServers() {
+    for (ServerDetector detector : SERVER_DETECTORS) {
+      logDebug("detect-server", detector.getClass().toString());
+      if (detector.detect()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   private static void awaitServerInitialization(final Instrumentation instrumentation) {
     for (ServerDetector detector : SERVER_DETECTORS) {
+      logDebug("await-server", detector.getClass().toString());
       detector.jvmAgentStartup(instrumentation);
     }
   }

--- a/src/main/java/com/heroku/agent/metrics/Poller.java
+++ b/src/main/java/com/heroku/agent/metrics/Poller.java
@@ -33,7 +33,7 @@ public class Poller {
     this.registry = CollectorRegistry.defaultRegistry;
   }
 
-  public void poll(final Callback callback) throws IOException {
+  public void poll(final Callback callback) {
     timer.scheduleAtFixedRate(new TimerTask() {
       @Override
       public void run() {

--- a/src/main/java/com/heroku/detector/AbstractServerDetector.java
+++ b/src/main/java/com/heroku/detector/AbstractServerDetector.java
@@ -1,0 +1,35 @@
+package com.heroku.detector;
+
+import java.lang.instrument.Instrumentation;
+
+public abstract class AbstractServerDetector implements ServerDetector {
+
+  /**
+   * By default do nothing during JVM agent startup
+   */
+  public void jvmAgentStartup(Instrumentation instrumentation) {
+  }
+
+  /**
+   * Tests if the given class name has been loaded by the JVM. Don't use this method
+   * in case you have access to the class loader which will be loading the class
+   * because the used approach is not very efficient.
+   * @param className the name of the class to check
+   * @param instrumentation the Instrumentation implementation
+   * @return true if the class has been loaded by the JVM
+   * @throws IllegalArgumentException in case instrumentation or the provided class is null
+   */
+  boolean isClassLoaded(String className, Instrumentation instrumentation) {
+    if (instrumentation == null || className == null) {
+      throw new IllegalArgumentException("instrumentation and className must not be null");
+    }
+    Class<?>[] classes = instrumentation.getAllLoadedClasses();
+    for (Class<?> c : classes) {
+      if (className.equals(c.getName())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+}

--- a/src/main/java/com/heroku/detector/AbstractServerDetector.java
+++ b/src/main/java/com/heroku/detector/AbstractServerDetector.java
@@ -5,6 +5,13 @@ import java.lang.instrument.Instrumentation;
 public abstract class AbstractServerDetector implements ServerDetector {
 
   /**
+   * By default do nothing
+   */
+  public boolean detect() {
+    return false;
+  }
+
+  /**
    * By default do nothing during JVM agent startup
    */
   public void jvmAgentStartup(Instrumentation instrumentation) {

--- a/src/main/java/com/heroku/detector/JBossDetector.java
+++ b/src/main/java/com/heroku/detector/JBossDetector.java
@@ -3,6 +3,12 @@ package com.heroku.detector;
 import java.lang.instrument.Instrumentation;
 
 public class JBossDetector extends AbstractServerDetector {
+
+  @Override
+  public boolean detect() {
+    return earlyDetectForJBossModulesBasedContainer(this.getClass().getClassLoader());
+  }
+
   /**
    * Attempts to detect a JBoss modules based application server. Because getting
    * access to the main arguments is not possible, it returns true in case the system property
@@ -38,7 +44,14 @@ public class JBossDetector extends AbstractServerDetector {
     // For Thorntail (Wildfly Swarm):
     String bootModuleLoader = System.getProperty("boot.module.loader");
     if (bootModuleLoader != null) {
+      System.out.println("bootModuleLoader: " + bootModuleLoader);
       return bootModuleLoader.contains("wildfly");
+    }
+    // For Thorntail (Wildfly Swarm):
+    String swarmPort = System.getProperty("swarm.http.port");
+    if (swarmPort != null) {
+      System.out.println("swarmPort: " + swarmPort);
+      return true;
     }
     return false;
   }

--- a/src/main/java/com/heroku/detector/JBossDetector.java
+++ b/src/main/java/com/heroku/detector/JBossDetector.java
@@ -1,0 +1,77 @@
+package com.heroku.detector;
+
+import java.lang.instrument.Instrumentation;
+
+public class JBossDetector extends AbstractServerDetector {
+  /**
+   * Attempts to detect a JBoss modules based application server. Because getting
+   * access to the main arguments is not possible, it returns true in case the system property
+   * {@code jboss.modules.system.pkgs} is set and the {@code org/jboss/modules/Main.class} resource can be found
+   * using the class loader of this class.
+   *
+   * If so, it awaits the early initialization of a JBoss modules based application server by polling the system property
+   * {@code java.util.logging.manager} and waiting until the specified class specified by this property has been
+   * loaded by the JVM.
+   */
+  @Override
+  public void jvmAgentStartup(Instrumentation instrumentation) {
+    jvmAgentStartup(instrumentation, this.getClass().getClassLoader());
+  }
+
+  protected void jvmAgentStartup(Instrumentation instrumentation, ClassLoader classLoader) {
+    if (earlyDetectForJBossModulesBasedContainer(classLoader)) {
+      awaitServerInitializationForJBossModulesBasedContainer(instrumentation);
+    }
+  }
+
+  private boolean earlyDetectForJBossModulesBasedContainer(ClassLoader classLoader) {
+    return hasWildflyProperties() &&
+        // Contained in any JBoss modules app:
+        classLoader.getResource("org/jboss/modules/Main.class") != null;
+  }
+
+  private boolean hasWildflyProperties() {
+    // For Wildfly AS:
+    if (System.getProperty("jboss.modules.system.pkgs") != null) {
+      return true;
+    }
+    // For Thorntail (Wildfly Swarm):
+    String bootModuleLoader = System.getProperty("boot.module.loader");
+    if (bootModuleLoader != null) {
+      return bootModuleLoader.contains("wildfly");
+    }
+    return false;
+  }
+
+  // Wait a max 5 Minutes
+  private static final int LOGGING_DETECT_TIMEOUT = 5 * 60 * 1000;
+  private static final int LOGGING_DETECT_INTERVAL = 200;
+
+  private void awaitServerInitializationForJBossModulesBasedContainer(Instrumentation instrumentation) {
+    int count = 0;
+    while (count * LOGGING_DETECT_INTERVAL < LOGGING_DETECT_TIMEOUT) {
+      String loggingManagerClassName = System.getProperty("java.util.logging.manager");
+      if (loggingManagerClassName != null) {
+        if (isClassLoaded(loggingManagerClassName, instrumentation)) {
+          // Assuming that the logging manager (most likely org.jboss.logmanager.LogManager)
+          // is loaded by the static initializer of java.util.logging.LogManager (and not by
+          // other code), we know now that either the java.util.logging.LogManager singleton
+          // is or will be initialized.
+          // Here where trigger to for load the class:
+          // https://github.com/jboss-modules/jboss-modules/blob/1.5.1.Final/src/main/java/org/jboss/modules/Main.java#L482
+          // Therefore the steps 3-6 of the proposal for option 2 don't need to be performed,
+          // see https://github.com/rhuss/jolokia/issues/258 for details.
+          return;
+        }
+      }
+      try {
+        Thread.sleep(LOGGING_DETECT_INTERVAL);
+        count++;
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+    }
+    throw new IllegalStateException(String.format("Detected JBoss Module loader, but property java.util.logging.manager is not set after %d seconds", LOGGING_DETECT_TIMEOUT / 1000));
+  }
+
+}

--- a/src/main/java/com/heroku/detector/ServerDetector.java
+++ b/src/main/java/com/heroku/detector/ServerDetector.java
@@ -4,6 +4,8 @@ import java.lang.instrument.Instrumentation;
 
 public interface ServerDetector {
 
+  boolean detect();
+
   /**
    * Notify detector that the JVM is about to start. A detector can, if needed, block and wait for some condition but
    * should ultimatevely return at some point or throw an exception. This notification is executed

--- a/src/main/java/com/heroku/detector/ServerDetector.java
+++ b/src/main/java/com/heroku/detector/ServerDetector.java
@@ -1,0 +1,14 @@
+package com.heroku.detector;
+
+import java.lang.instrument.Instrumentation;
+
+public interface ServerDetector {
+
+  /**
+   * Notify detector that the JVM is about to start. A detector can, if needed, block and wait for some condition but
+   * should ultimatevely return at some point or throw an exception. This notification is executed
+   * in a very early stage (premain of the JVM agent) before the main class of the Server is executed.
+   * @param instrumentation the Instrumentation implementation
+   */
+  void jvmAgentStartup(Instrumentation instrumentation);
+}

--- a/src/test/java/com/heroku/detector/JBossDetectorTest.java
+++ b/src/test/java/com/heroku/detector/JBossDetectorTest.java
@@ -1,0 +1,80 @@
+package com.heroku.detector;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.lang.instrument.Instrumentation;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.*;
+
+public class JBossDetectorTest {
+
+  private JBossDetector detector;
+
+  @Before
+  public void setup() {
+    detector = new JBossDetector();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void verifyIsClassLoadedArgumentChecksNullInstrumentation() {
+    detector.isClassLoaded("xx", null);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void verifyIsClassLoadedArgumentChecks2NullClassname() {
+    detector.isClassLoaded(null, mock(Instrumentation.class));
+  }
+
+  @Test
+  public void verifyIsClassLoadedNotLoaded() {
+    Instrumentation inst = mock(Instrumentation.class);
+    when(inst.getAllLoadedClasses()).thenReturn(new Class[] {});
+    assertFalse(detector.isClassLoaded("org.Dummy", inst));
+    verify(inst, times(1)).getAllLoadedClasses();
+  }
+
+  @Test
+  public void verifyIsClassLoadedLoaded() {
+    Instrumentation inst = mock(Instrumentation.class);
+    when(inst.getAllLoadedClasses()).thenReturn(new Class[] {JBossDetectorTest.class});
+    assertTrue(detector.isClassLoaded(JBossDetectorTest.class.getName(), inst));
+    verify(inst, times(1)).getAllLoadedClasses();
+  }
+
+  @Test
+  public void verifyJvmAgentStartup() throws MalformedURLException {
+    Instrumentation inst = mock(Instrumentation.class);
+    when(inst.getAllLoadedClasses()).
+        thenReturn(new Class[] {}).
+        thenReturn(new Class[] {}).
+        thenReturn(new Class[] {}).
+        thenReturn(new Class[] {JBossDetectorTest.class});
+    ClassLoader cl = mock(ClassLoader.class);
+    when(cl.getResource("org/jboss/modules/Main.class")).thenReturn(new URL("http", "dummy", ""));
+    String prevPkgValue = System.setProperty("jboss.modules.system.pkgs", "blah");
+    String prevLogValue = System.setProperty("java.util.logging.manager", JBossDetectorTest.class.getName());
+
+    try {
+      detector.jvmAgentStartup(inst, cl);
+
+      verify(inst, atLeast(3)).getAllLoadedClasses();
+      verify(cl, atLeastOnce()).getResource("org/jboss/modules/Main.class");
+    } finally {
+      resetSysProp(prevLogValue, "java.util.logging.manager");
+      resetSysProp(prevPkgValue, "jboss.modules.system.pkgs");
+    }
+  }
+
+  private void resetSysProp(String prevValue, String key) {
+    if (prevValue == null) {
+      System.getProperties().remove(key);
+    } else {
+      System.setProperty(key, prevValue);
+    }
+  }
+}


### PR DESCRIPTION
If the agent is started first it takes over the logging, which causes Thorntail to fail to start. Thus, we detect when Thorntail, Wildfly, or JBoss are in use, and sleep until the logger is loaded.

Fixes #4 