### PR TITLE
Use maven-shade-plugin to relocate dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,31 +91,34 @@
         </configuration>
       </plugin>
       <plugin>
-        <artifactId>maven-assembly-plugin</artifactId>
-        <version>3.1.0</version>
-        <configuration>
-          <descriptorRefs>
-            <descriptorRef>jar-with-dependencies</descriptorRef>
-          </descriptorRefs>
-          <appendAssemblyId>false</appendAssemblyId>
-          <archive>
-            <index>true</index>
-            <manifest>
-                <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-                <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
-            </manifest>
-            <manifestEntries>
-              <Premain-Class>com.heroku.agent.metrics.MetricsAgent</Premain-Class>
-            </manifestEntries>
-          </archive>
-        </configuration>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.2.1</version>
         <executions>
           <execution>
-            <id>build-jar-with-dependencies</id>
             <phase>package</phase>
             <goals>
-              <goal>single</goal>
+              <goal>shade</goal>
             </goals>
+            <configuration>
+              <relocations>
+                <relocation>
+                  <pattern>com.fasterxml</pattern>
+                  <shadedPattern>com.heroku.shaded.com.fasterxml</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>io.prometheus</pattern>
+                  <shadedPattern>com.heroku.shaded.io.prometheus</shadedPattern>
+                </relocation>
+              </relocations>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <manifestEntries>
+                    <Premain-Class>com.heroku.agent.metrics.MetricsAgent</Premain-Class>
+                  </manifestEntries>
+                </transformer>
+              </transformers>
+            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
From the [java.lang.instrument docs: ](https://docs.oracle.com/en/java/javase/11/docs/api/java.instrument/java/lang/instrument/package-summary.html)
 > Classes loaded from the agent JAR file are loaded by the system class loader and are members of the system class loader's unnamed module.

This means all classes within `heroku-java-metrics-agent` will be visible to the instrumented application as well. This most likely caused #9. I tested this locally with a bunch of different JVM implementations/versions and I was able to load classes from our dependencies with the system class loader with all of them. This might cause issues when the user application uses the same dependency with a different version.

This PR adds prefixing the packages of our dependencies we use within this project with `com.heroku.shaded` in the package phase. This should mitigate the problem. Testing showed that #9 is resolved by this measure.