### PR TITLE
Reduce Dependabot frequency to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,4 @@ updates:
   - package-ecosystem: "maven"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"


### PR DESCRIPTION
To reduce the churn + email notification noise slightly. GitHub will still open PRs for any security issues outside of the monthly cadence.