### PR TITLE
Downgrade to Java 11 for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: zulu
-          java-version: 17
+          java-version: 11
       - run: "./mvnw --batch-mode clean verify package"
       - uses: actions/upload-artifact@v3
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -91,9 +91,9 @@
                     <source>7</source>
                     <target>7</target>
                     <release>7</release>
-                    <testSource>17</testSource>
-                    <testTarget>17</testTarget>
-                    <testRelease>17</testRelease>
+                    <testSource>11</testSource>
+                    <testTarget>11</testTarget>
+                    <testRelease>11</testRelease>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Our release automation builds with Java 11 and therefore cannot compile with `--release 17`. Since we don't use any Java 17 feature in testing anyway, we can safely downgrade to 11. This re-enables releasing with our automation.