### PR TITLE
Move Reporter logging of non-200 HTTP responses to debug level

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,7 @@ Users of these buildpacks don't need to work with this agent directly.
 
 Users that use custom buildpacks or Heroku's [container runtime](https://devcenter.heroku.com/articles/container-registry-and-runtime) can set up this agent manually to get JVM runtime metrics in
 Heroku's dashboard. Add `-javaagent:/path/to/heroku-metrics-agent.jar` to your main `java` process (i.e. in your app's [Procfile](https://devcenter.heroku.com/articles/procfile) or your Dockerfile's [`CMD` instruction](https://docs.docker.com/engine/reference/builder/#cmd)). It will automatically configure itself when run on Heroku and does nothing when run elsewhere.
+
+## Debugging
+
+To enable more detailed logging, set the `HEROKU_METRICS_DEBUG` environment variable to `true`.

--- a/src/main/java/com/heroku/agent/metrics/Logger.java
+++ b/src/main/java/com/heroku/agent/metrics/Logger.java
@@ -15,17 +15,23 @@ public final class Logger {
     }
   }
 
-  public static void logResponseError(String at, String message, long status, String response) {
-    System.out.println(
-        "error at=\""
-            + at
-            + "\" component=heroku-java-metrics-agent message=\""
-            + message
-            + "\" status="
-            + status
-            + " response=\""
-            + response
-            + "\"");
+  public static void logReporterResponseError(
+      String at, String message, long status, String response) {
+    // The metrics endpoint returns 401 and 429 from time to time. These errors aren't harmful as
+    // the request will be automatically retried. Customers previously reported log clutter due to these messages. Since
+    // these errors are not actionable for the customer, we now only log at the debug level.
+    if (isDebugEnabled()) {
+      System.out.println(
+          "debug at=\""
+              + at
+              + "\" component=heroku-java-metrics-agent message=\""
+              + message
+              + "\" status="
+              + status
+              + " response=\""
+              + response
+              + "\"");
+    }
   }
 
   private static String formatLogLine(String level, String at, String message) {

--- a/src/main/java/com/heroku/agent/metrics/Reporter.java
+++ b/src/main/java/com/heroku/agent/metrics/Reporter.java
@@ -42,11 +42,15 @@ public class Reporter {
       // HTTP client error status codes
       if (responseCode >= 400 && responseCode < 500) {
         try {
-          Logger.logResponseError(
-              "send-post",
-              "upstream service error",
-              responseCode,
-              Utils.readAllUtf8(connection.getInputStream()));
+          InputStream errorStream = connection.getErrorStream();
+          String errorStreamAsString = "<response-without-body>";
+
+          if (errorStream != null) {
+            errorStreamAsString = Utils.readAllUtf8(errorStream);
+          }
+
+          Logger.logReporterResponseError(
+              "send-post", "upstream service error", responseCode, errorStreamAsString);
         } catch (IOException e) {
           Logger.logException("send-post", e);
         }


### PR DESCRIPTION
The metrics endpoint returns 401 and 429 from time to time. These errors aren't harmful as the request will be automatically retried. Customers previously reported log clutter due to these messages. Since these errors are not actionable for the customer, we now only log at the debug level.

Closes: GUS-W-8209285
