### PR TITLE
Prepare next development iteration 4.0.3-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.heroku.agent</groupId>
     <artifactId>heroku-java-metrics-agent</artifactId>
-    <version>4.0.2</version>
+    <version>4.0.3-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>heroku-java-metrics-agent</name>
     <description>


### PR DESCRIPTION
(Manually created because Maven Central signalled a release failure but still released - this means we cannot release 4.0.2 again.)