### PR TITLE
Fix Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,7 @@ updates:
           - "minor"
           - "patch"
         patterns:
-	  - "org.apache.maven.plugins:*"
+          - "org.apache.maven.plugins:*"
   - package-ecosystem: "cargo"
     directory: "/integration-test"
     schedule:


### PR DESCRIPTION
Even though @edmorley pointed out a potential issue with line 17 I didn't see the issue and merged. Dependabot complained about that line and here we are with the third attempt to update the Dependabot config. Somehow my editor decided to incorrectly display whitespace, a restart showed the glaring issue again.

This is embarrassing. :/