### PR TITLE
Simplify Cargo metadata for `publish = false` crates

### DIFF
--- a/integration-test/Cargo.toml
+++ b/integration-test/Cargo.toml
@@ -1,8 +1,7 @@
 [package]
 name = "integration-test"
-version = "0.0.0"
 edition = "2021"
-publish = false
+rust-version = "1.75"
 
 [dependencies]
 rouille = "3.6.2"


### PR DESCRIPTION
As of Cargo 1.75 the `version` property in `Cargo.toml` is now optional, and if omitted is the same as having specified `version = "0.0.0"` and `publish = false`:
https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-175-2023-12-28
https://doc.rust-lang.org/cargo/reference/manifest.html#the-version-field

Therefore for crates that we do not publish, we can now remove both the `version` and `publish` properties, avoiding the need for the fake `0.0.0` version that differs from the actual buildpack version in `buildpack.toml`.

GUS-W-14821120.