### PR TITLE
Switch to Cargo.toml based lint configuration

### DIFF
--- a/integration-test/Cargo.toml
+++ b/integration-test/Cargo.toml
@@ -3,6 +3,13 @@ name = "integration-test"
 edition = "2021"
 rust-version = "1.75"
 
+[lints.rust]
+unreachable_pub = "warn"
+unused_crate_dependencies = "warn"
+
+[lints.clippy]
+pedantic = "warn"
+
 [dependencies]
 chrono = "0.4"
 clap = { version= "4", features = ["derive"] }

--- a/integration-test/src/constants.rs
+++ b/integration-test/src/constants.rs
@@ -1,6 +1,6 @@
 use crate::JavaGarbageCollector;
 
-pub const GC_SPECIFIC_COUNTERS: [(&str, JavaGarbageCollector); 12] = [
+pub(crate) const GC_SPECIFIC_COUNTERS: [(&str, JavaGarbageCollector); 12] = [
     (
         "jvm_gc_collection_seconds_count.gc_PS_Scavenge",
         JavaGarbageCollector::Parallel,
@@ -55,9 +55,9 @@ pub const GC_SPECIFIC_COUNTERS: [(&str, JavaGarbageCollector); 12] = [
 // - jvm_gc_collection_seconds_sum.gc_all
 // It is referenced in some places but seems to be unused. We don't test for it but leave
 // this comment should anyone encounter this metric count name in the future.
-pub const GENERIC_JVM_COUNTERS: [&str; 1] = ["jvm_gc_collection_seconds_count.gc_all"];
+pub(crate) const GENERIC_JVM_COUNTERS: [&str; 1] = ["jvm_gc_collection_seconds_count.gc_all"];
 
-pub const GENERIC_JVM_GAUGES: [&str; 6] = [
+pub(crate) const GENERIC_JVM_GAUGES: [&str; 6] = [
     "jvm_memory_bytes_used.area_heap",
     "jvm_memory_bytes_used.area_nonheap",
     "jvm_buffer_pool_bytes_used.name_direct",

--- a/integration-test/src/gc.rs
+++ b/integration-test/src/gc.rs
@@ -1,7 +1,7 @@
 use clap::builder::PossibleValue;
 
 #[derive(Clone, Copy, Eq, PartialEq, Debug)]
-pub enum JavaGarbageCollector {
+pub(crate) enum JavaGarbageCollector {
     ConcurrentMarkSweep,
     Parallel,
     G1,

--- a/integration-test/src/main.rs
+++ b/integration-test/src/main.rs
@@ -1,6 +1,3 @@
-#![warn(clippy::pedantic)]
-#![warn(unused_crate_dependencies)]
-
 mod constants;
 mod gc;
 mod mock_metrics_server;

--- a/integration-test/src/mock_metrics_server.rs
+++ b/integration-test/src/mock_metrics_server.rs
@@ -5,7 +5,7 @@ use std::net::SocketAddrV4;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant, SystemTime};
 
-pub fn collect_requests(address: SocketAddrV4, duration: Duration) -> Vec<CollectedRequest> {
+pub(crate) fn collect_requests(address: SocketAddrV4, duration: Duration) -> Vec<CollectedRequest> {
     let collected_requests = Arc::new(Mutex::new(vec![]));
     let return_requests = collected_requests.clone();
 
@@ -52,8 +52,8 @@ pub fn collect_requests(address: SocketAddrV4, duration: Duration) -> Vec<Collec
 }
 
 #[derive(Debug)]
-pub struct CollectedRequest {
-    pub time: SystemTime,
-    pub headers: HashMap<String, String>,
-    pub body: Option<String>,
+pub(crate) struct CollectedRequest {
+    pub(crate) time: SystemTime,
+    pub(crate) headers: HashMap<String, String>,
+    pub(crate) body: Option<String>,
 }


### PR DESCRIPTION
As of the Cargo included in Rust 1.74, lints can now be configured in Cargo.toml across whole crates:
https://blog.rust-lang.org/2023/11/16/Rust-1.74.0.html
https://doc.rust-lang.org/stable/cargo/reference/manifest.html#the-lints-section

I've also enabled the `unreachable_pub` for parity with our other repos, eg:
https://github.com/heroku/buildpacks-jvm/blob/9c567cafc15206ae8c0cd2aeb2b4cfd171f9589b/Cargo.toml#L18-L26

I've not enabled the various panic/unwrap related lints used in our other repos, since the Rust usage in this repo is purely for tests, for which panicing is expected.

The `unreachable_pub` fixes were generated using `cargo clippy --fix`.

GUS-W-14836125.