### PR TITLE
Set Manuel as CODEOWNER for Cargo.toml/Cargo.lock

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,6 @@
 # However, request review from the language owner instead for files that are updated
 # by Dependabot or release automation, to reduce team review request noise.
 CHANGELOG.md @Malax
+Cargo.toml @Malax
+Cargo.lock @Malax
 pom.xml @Malax


### PR DESCRIPTION
This is a follow-up to #184, to add Rust specific files to the CODEOWNERS list (whilst this repo is Java-specific, it also contains Rust components for the integration tests).

This will ensure only Manuel is requested for review for PRs like #185.