### PR TITLE
Add OpenJDK 22 to CI suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
           - 19
           - 20
           - 21
+          - 22
         gc:
           - parallel
           - g1


### PR DESCRIPTION
Ensure that the agent is tested with OpenJDK 22