### PR TITLE
Update CI to Ubuntu 24.04 runner images

### DIFF
--- a/.github/workflows/check_changelog.yml
+++ b/.github/workflows/check_changelog.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   check-changelog:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: (!contains(github.event.pull_request.labels.*.name, 'skip changelog'))
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
   # in production, where the agent is built once and used across all OpenJDK versions.
   build-agent:
     name: "Build and verify"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -28,7 +28,7 @@ jobs:
           path: target/heroku-java-metrics-agent.jar
   integration-test:
     name: "Integration Test (Java ${{ matrix.java-version }}, GC: ${{ matrix.gc }})"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: build-agent
     strategy:
       matrix:
@@ -80,7 +80,7 @@ jobs:
         run: cargo run -- "../heroku-java-metrics-agent.jar" "${{ matrix.gc }}" "9876"
         working-directory: integration-test
   rust-lint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -12,7 +12,7 @@ defaults:
 jobs:
   prepare-release:
     name: Prepare Release
-    runs-on: pub-hk-ubuntu-22.04-small
+    runs-on: pub-hk-ubuntu-24.04-ip
     steps:
       - name: Get token for GH application (Linguist)
         uses: heroku/use-app-token-action@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     name: Release
     # Prevent accidentally performing a release from a branch other than `main`.
     if: github.ref == 'refs/heads/main'
-    runs-on: pub-hk-ubuntu-22.04-small
+    runs-on: pub-hk-ubuntu-24.04-ip
     steps:
       - name: Get token for GH application (Linguist)
         uses: heroku/use-app-token-action@main


### PR DESCRIPTION
Now that Ubuntu 24.04 images are available on GitHub Actions, we can update from the Ubuntu 22.04 images.

See also:
https://github.com/actions/runner-images/issues/9848
https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md
https://salesforce.quip.com/bu6UA0KImOxJ#temp:C:GZRd13d2ce2d455470495cbd34cf

GUS-W-16238120.