### PR TITLE
Add missing `--locked` to Cargo commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
         with:
           name: agent-jar
       - name: Run integration tests
-        run: cargo run -- "../heroku-java-metrics-agent.jar" "${{ matrix.gc }}" "9876"
+        run: cargo run --locked -- "../heroku-java-metrics-agent.jar" "${{ matrix.gc }}" "9876"
         working-directory: integration-test
   rust-lint:
     runs-on: ubuntu-24.04
@@ -91,7 +91,7 @@ jobs:
         with:
           workspaces: "./integration-test"
       - name: Clippy
-        run: cargo clippy --all-targets --all-features -- --deny warnings
+        run: cargo clippy --all-targets --all-features --locked -- --deny warnings
         working-directory: integration-test
       - name: rustfmt
         run: cargo fmt -- --check


### PR DESCRIPTION
The Cargo `--locked` argument ensures that Cargo will fail with an error if `Cargo.lock` is out of sync with `Cargo.toml`, rather than the lockfile being silently updated.

As such, in CI we should always be using `--locked` for projects that have committed their lockfile to Git (which should be the case for most projects other than those that are libraries).

After seeing that `cnb-otel-collector` didn't use `--locked` in all cases, I audited all of our Rust repos and found others missing `--locked` too.

GUS-W-18062544.